### PR TITLE
Added tracing feature to atomsim debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ cpp_driver_source = sim/$(cpp_driver)
 build_dir = build
 bin_dir = $(build_dir)/bin
 object_dir = $(build_dir)/obj_dir
+trace_dir = $(build_dir)/trace
 
 # Executable
 executable_name = atomsim
@@ -21,9 +22,9 @@ executable_name = atomsim
 ###	ADVANCED CONFIGURATIONS
 verilator_includes = -I obj_dir -I /usr/share/verilator/include -I /usr/share/verilator/include/vltstd
 linking = #-lncurses
-verilated_path = /usr/share/verilator/include/verilated.cpp
+verilated_path = /usr/share/verilator/include/verilated.cpp /usr/share/verilator/include/verilated_vcd_c.cpp
 gpp_flags = #-pthread
-verilator_flags = -cc -Wall --relative-includes
+verilator_flags = -cc -Wall --relative-includes --trace
 
 ########################################################################
 default: clean atomsim
@@ -47,6 +48,10 @@ $(bin_dir):
 	mkdir $(bin_dir)
 	@echo ">> Creating directory $(bin_dir) -- done\n"
 
+$(trace_dir):
+	@echo ">> Creating directory $(trace_dir)"
+	mkdir $(trace_dir)
+	@echo ">> Creating directory $(trace_dir) -- done\n"
 
 # Verilate verilog
 $(object_dir)/V$(topmodule)__ALL.a: 
@@ -66,7 +71,7 @@ $(bin_dir)/$(executable_name): $(object_dir)/V$(topmodule)__ALL.a
 
 
 .PHONY: atomsim
-atomsim: $(build_dir) $(bin_dir) $(bin_dir)/$(executable_name)
+atomsim: $(build_dir) $(bin_dir) $(trace_dir) $(bin_dir)/$(executable_name)
 
 
 #.PHONY: sim

--- a/sim/AtomSim.cpp
+++ b/sim/AtomSim.cpp
@@ -15,13 +15,20 @@ const unsigned int mSec = 1000;
 // Simulation Parameters
 unsigned int delay_amt = 100 * mSec; //default 
 
+// This is used to display reason for simulation termination
+std::string end_simulation_reason;
+
 #include "defs.hpp"
 #include "backend.hpp"
 
 
 bool verbose_flag = false;
 bool debug_mode = false;
+bool trace_enabled = false;
+
 std::string ifile = "";
+
+std::string trace_dir;
 
 /**
  * @brief parses command line arguments given to the assembler and 
@@ -63,6 +70,17 @@ bool parse_commandline_args(const int argc, char**argv)
             {
                 std::cout << Info_short_help_msg;
                 return true;
+            }
+			else if(argument == "--trace-dir")                           // print long help message
+            {
+                if(i == argc-1)
+				{
+					std::cerr << "!Error: Trace directory not provided\n";
+                	return true;
+				}
+				i++;
+				trace_dir = argv[i];
+				i++;
             }
             else if(argument == "--help")                           // print long help message
             {
@@ -106,6 +124,10 @@ void tick(long unsigned int cycles, Backend * b)
 {
 	for(long unsigned int i=0; i<cycles && !b->done(); i++)
 	{
+		if(b->done())
+		{
+			break;
+		}
 	 	b->refreshData();
 	 	b->displayData();
 	 	b->tick();
@@ -127,7 +149,7 @@ int main(int argc, char **argv)
 	std::cout << "  File : "<< ifile <<"      Ready...\n\n";
 
 	// Initialize verilator
-	Verilated::commandArgs(argc, argv);	
+	Verilated::commandArgs(argc, argv);
 
 	Backend bkend(ifile);
 
@@ -136,6 +158,11 @@ int main(int argc, char **argv)
 	{
 		while(true)
 		{
+			if(bkend.done())
+			{
+				end_simulation_reason = "Backend encountered a $finish";
+				break;
+			}
 			// Parse Input
 			std::cout << ": ";
 			getline(std::cin, input);
@@ -148,24 +175,64 @@ int main(int argc, char **argv)
 			//	std::cout <<" \""<< token[i] <<"\"";
 			//std::cout <<" ]\n";
 
-			if(token[0] == "q")
+			if(token[0] == "q" | token[0] == "quit")
 			{
+				// Quit simulator
+				end_simulation_reason = "User interruption";
 				break;
 			}
 			else if(token[0] == "r")
 			{
+				// Run indefinitely
+				tick(-1, &bkend);
+			}
+			else if(token[0] == "rst")
+			{
+				// Reset Simulator
 				bkend.reset();
 			}
 			else if(token[0] == "")
 			{
+				// Run for 2 cycles
 				tick(2, &bkend);
 			}
 			else if(token[0] == "run")
 			{
+				// run for specified cycles
 				if(token.size()<2)
 					std::cout << "!ERROR: run expects one argument" <<"\n";
 				else
 					tick(std::stoi(token[1]), &bkend);
+			}
+			else if(token[0] == "trace")
+			{
+				// Enable trace
+				if(token.size()<2)
+					std::cout << "!ERROR: trace command expects a filename" <<"\n";
+				else
+				{
+					if(trace_enabled == false)
+					{
+						std::string tracefile = trace_dir+"/"+token[1];
+						bkend.tb->openTrace(tracefile.c_str());
+						std::cout << "Trace enabled : \"" << tracefile << "\" opened for output.\n";
+						trace_enabled = true;
+					}
+					else
+						std::cout << "Trace was already enabled\n";
+				}
+			}
+			else if(token[0] == "notrace")
+			{
+				// Disable trace
+				if(trace_enabled == true)
+				{
+					bkend.tb->closeTrace();
+					std::cout << "Trace disabled\n";
+					trace_enabled = false;
+				}
+				else
+					std::cout << "Trace was not enabled \n";
 			}
 			else
 			{
@@ -179,6 +246,9 @@ int main(int argc, char **argv)
 	{
 		tick(-1, &bkend);
 	}
+	std::cout << "Simulation ended @ tick " << bkend.tb->m_tickcount_total << " due to : " << end_simulation_reason << std::endl;
+	if(trace_enabled)
+		bkend.tb->closeTrace();
 	exit(EXIT_SUCCESS);    
 }
 


### PR DESCRIPTION
Modified makefile to verilate with --trace option, Modified
Atomsim.cpp to support trace related commands in debug console,
Modified backend to support tracing.

Debug mode tracing commands:
        1. enable tracing  : trace <filename>
        2. disable tracing : notrace

Directory to store trace files can now be specified to the
atomsim executable using --trace-dir <directory> option