### PR TITLE
Code Refactoring: Atomsim Frontend, Backend & SCAR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ $(vobject_dir)/V$(verilog_topmodule)__ALLsup.o $(vobject_dir)/V$(verilog_topmodu
 	cd $(vobject_dir) && make -f V$(verilog_topmodule).mk
 
 # Compile C++ files
-$(cobject_dir)/atomsim.o: $(sim_dir)/AtomSim.cpp $(sim_dir)/defs.hpp $(sim_dir)/Testbench.hpp $(sim_cpp_backend)
+$(cobject_dir)/atomsim.o: $(sim_dir)/AtomSim.cpp $(sim_dir)/defs.hpp $(sim_dir)/Backend.hpp $(sim_dir)/Testbench.hpp $(sim_cpp_backend)
 	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@
 
 $(cobject_dir)/verilated.o: /usr/share/verilator/include/verilated.cpp 

--- a/rtl/Config.vh
+++ b/rtl/Config.vh
@@ -1,5 +1,5 @@
 // Config file
-`define RESET_PC_ADDRESS 32'h0000100
+`define RESET_PC_ADDRESS 32'h0000000
 
 `define __NOP_INSTRUCTION__ 32'h00000013    // NOP = addi x0, x0, 0
 

--- a/sim/Backend.hpp
+++ b/sim/Backend.hpp
@@ -1,0 +1,162 @@
+#ifndef __BACKEND_HPP__
+#define __BACKEND_HPP__
+
+#include <stdint.h>
+#include <map>
+#include <string>
+#include "Testbench.hpp"
+
+/**
+ * @brief Backend class
+ * Backend class encapsulates the data 
+ * probing and printing operations
+ */
+template <class VTarget>
+class Backend
+{
+	public:
+	/**
+	 * @brief Pointer to testbench object
+	 */
+	Testbench<VTarget> *tb;
+
+	/**
+	 * @brief Struct to hold CPU state
+	 */
+    struct CPUState
+    {
+        // Fetch-Stage
+        unsigned int pc_f;
+        unsigned int ins_f;
+
+        // Execute Stage
+        unsigned int pc_e;
+        unsigned int ins_e;
+        
+        // Register File
+        unsigned int rf[32];
+    } state;
+
+    /**
+     * @brief Struct to hold CPU signal values
+     */
+    struct CPUSignals
+    {
+        bool jump_decision;
+    } signals;
+
+    /**
+     * @brief Disassembly of input file
+     */
+	std::map<uint32_t, std::string> disassembly;
+
+    private:
+    /**
+     * @brief Register ABI names used in debug display
+     */
+    const std::vector<std::string> reg_names = 
+    {
+        "x0  (zero) ",	"x1  (ra)   ",	"x2  (sp)   ",	"x3  (gp)   ",	"x4  (tp)   ",	"x5  (t0)   ",	"x6  (t1)   ",	"x7  (t2)   ",
+        "x8  (s0/fp)",	"x9  (s1)   ",	"x10 (a0)   ",	"x11 (a1)   ",	"x12 (a2)   ",	"x13 (a3)   ",	"x14 (a4)   ",	"x15 (a5)   ",
+        "x16 (a6)   ",	"x17 (a7)   ",	"x18 (s2)   ",	"x19 (s3)   ",	"x20 (s4)   ",	"x21 (s5)   ",	"x22 (s6)   ",	"x23 (s7)   ",
+        "x24 (s8)   ",	"x25 (s9)   ",	"x26 (s10)  ",	"x27 (s11)  ",	"x28 (t3)   ",	"x29 (t4)   ",	"x30 (t5)   ",	"x31 (t6)   "
+    };
+
+    public:
+	/**
+	 * @brief reset the backend
+	 */
+	void reset()
+    {
+        if(verbose_flag)
+            std::cout << "Resetting..\n";
+        tb->reset();
+    }
+
+	/**
+	 * @brief probe all internal signals and regsters and 
+	 * update backend state
+	 */
+	virtual void refreshData() = 0;
+
+	/**
+	 * @brief Display state data on console
+	 */
+	void displayData()
+    {
+        // calculate change in PC.
+        unsigned int pc_change = state.pc_f - state.pc_e;
+
+        bool isJump = signals.jump_decision;
+        static bool wasJump = false;
+        
+        // Print debug screen
+        std::cout << "-< " << tb->m_tickcount_total <<" >------------------------------------------------\n";
+        printf("F  pc : 0x%08x  (%+d) <%s> \n", state.pc_f , pc_change, (isJump ? "jump": " ")); 
+        
+        #define STYLE_BOLD         "\033[1m"
+        #define STYLE_NO_BOLD      "\033[22m"
+
+        #define STYLE_UNDERLINE    "\033[4m"
+        #define STYLE_NO_UNDERLINE "\033[24m"
+
+        printf("E  ");
+
+        printf(STYLE_BOLD);
+        printf("pc : 0x%08x   ir : 0x%08x\n", state.pc_e , state.ins_e); 
+        printf(STYLE_NO_BOLD);
+        
+        std::cout << "[ " <<  disassembly[state.pc_e] << " ]";
+
+        if(wasJump)
+            std::cout << " => nop (pipeline flush)";
+        
+        std::cout << "\n\n";
+        wasJump = isJump;
+
+        // Print Register File
+        if(verbose_flag)
+        {
+            int cols = 2; // no of coloumns per rows
+            #ifndef DEBUG_PRINT_T2B
+            for(int i=0; i<32; i++)	// print in left-right fashion
+            {
+                printf("r%-2d: 0x%08x   ", i, state.rf[i]);
+                if(i%cols == cols-1)
+                    printf("\n");
+            }
+            #else
+            for(int i=0; i<32/cols; i++)	// print in topdown fashion
+            {
+                for(int j=0; j<cols; j++)
+                {
+                    printf(" %s: 0x%08x  ", reg_names[i+(32/cols)*j].c_str(), state.rf[i+(32/cols)*j]);
+                }
+                printf("\n");
+            }
+            #endif
+        }
+    }
+
+	/**
+	 * @brief Tick for one cycle
+	 * 
+	 */
+	void tick()
+    {
+        tb->tick();
+    }
+
+	/**
+	 * @brief check if simulation is done
+	 * 
+	 * @return true 
+	 * @return false 
+	 */
+	bool done()
+    {
+        return tb->done();
+    }
+};
+
+#endif //__BACKEND_HPP__

--- a/sim/Testbench.hpp
+++ b/sim/Testbench.hpp
@@ -14,8 +14,8 @@ class Testbench
 
 	VTop 			* m_core = NULL;
 	VerilatedVcdC	* m_trace = NULL;
-	unsigned long 	m_tickcount;     			// TickCounter to count clock cycles fom last reset
-	unsigned long 	m_tickcount_total;   		// TickCounter to count clock cycles
+	unsigned long 	m_tickcount = 0;     			// TickCounter to count clock cycles fom last reset
+	unsigned long 	m_tickcount_total = 0;   		// TickCounter to count clock cycles
 
 	/**
 	 * @brief Construct a new TESTBENCH object

--- a/sim/defs.hpp
+++ b/sim/defs.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief Version information
  */
-const char Info_version[] = "AtomSim v1.0";
+const char Info_version[] = "AtomSim v1.1";
 
 /**
  * @brief Copyright message
@@ -38,27 +38,18 @@ const std::string  COLOR_YELLOW =  "\033[33m";
 
 // ================================ THROWING ERRORS =======================================
 /**
- * @brief Exits the program
- */
-void Exit()
-{
-    std::exit(EXIT_FAILURE);
-}
-
-
-/**
  * @brief Throws error generated in the std::cerr stream
  * 
  * @param er_code error code 
  * @param message error message
  * @param exit flag that tells weather to exit immidiately
  */
-void throwError(std::string er_code, std::string message, bool exit = false)
+void throwError(std::string er_code, std::string message, bool Exit = false)
 {
     std::cerr << COLOR_RED <<"! ERROR  (E"<< er_code <<"): " << COLOR_RESET << message << std::endl;
-    if(exit)
+    if(Exit)
     {
-        Exit();
+        ExitAtomSim("", true);
     }
 }
 
@@ -80,9 +71,13 @@ void throwWarning(std::string wr_code, std::string message)
  * 
  * @param message Success message
  */
-void throwSuccessMessage(std::string message)
+void throwSuccessMessage(std::string message, bool Exit = false)
 {
     std::cout << COLOR_GREEN <<"SUCCESS : " << COLOR_RESET  << message <<std::endl;
+    if(Exit)
+    {
+        ExitAtomSim("");
+    }
 }
 
 

--- a/test/scar/Makefile
+++ b/test/scar/Makefile
@@ -1,6 +1,8 @@
 ##########################
 PY = python3
 
+default: clean verify
+
 verify: directories
 	$(PY) scar.py
 


### PR DESCRIPTION
- All target specific backends inherit from backend class.
- All target specific code moved to its corresponding derived
  backend class.
- add support for hex & binary addresses in mem command in debug cli.
- AtomSim debug UI changes.
- Exiting AtomSim by any means calls the backend destructor.
- SCAR UI Changes.
- Runtime failed tests are now ignored instead of marking them as
  passed.